### PR TITLE
Add LoongArch support for numpy

### DIFF
--- a/numpy/core/include/numpy/npy_cpu.h
+++ b/numpy/core/include/numpy/npy_cpu.h
@@ -18,6 +18,7 @@
  *              NPY_CPU_ARCEL
  *              NPY_CPU_ARCEB
  *              NPY_CPU_RISCV64
+ *              NPY_CPU_LOONGARCH
  */
 #ifndef _NPY_CPUARCH_H_
 #define _NPY_CPUARCH_H_
@@ -102,6 +103,8 @@
     #define NPY_CPU_ARCEB
 #elif defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64
     #define NPY_CPU_RISCV64
+#elif defined(__loongarch__)
+    #define NPY_CPU_LOONGARCH
 #else
     #error Unknown CPU, please report this to numpy maintainers with \
     information about your platform (OS, CPU and compiler)

--- a/numpy/core/include/numpy/npy_endian.h
+++ b/numpy/core/include/numpy/npy_endian.h
@@ -48,7 +48,8 @@
             || defined(NPY_CPU_MIPSEL)        \
             || defined(NPY_CPU_PPC64LE)       \
             || defined(NPY_CPU_ARCEL)         \
-            || defined(NPY_CPU_RISCV64)
+            || defined(NPY_CPU_RISCV64)       \
+            || defined(NPY_CPU_LOONGARCH)
         #define NPY_BYTE_ORDER NPY_LITTLE_ENDIAN
     #elif defined(NPY_CPU_PPC)                \
             || defined(NPY_CPU_SPARC)         \

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2399,7 +2399,7 @@ def _selected_real_kind_func(p, r=0, radix=0):
     if p < 16:
         return 8
     machine = platform.machine().lower()
-    if machine.startswith(('aarch64', 'power', 'ppc', 'riscv', 's390x', 'sparc')):
+    if machine.startswith(('aarch64', 'loongarch', 'power', 'ppc', 'riscv', 's390x', 'sparc')):
         if p <= 20:
             return 16
     else:


### PR DESCRIPTION
Add LoongArch support for numpy， please review, thanks!   @loongarch64/dev-team 
kind 返回值的情况：
```
loongson@loongson-pc:~$ cat getKind.f90 
program getKind
        implicit none
        integer:: i
        i = selected_real_kind (p = 17, r = 0) 
        print *,'selected_real_kind (p = 17, r = 0):', i
End program getKind


loongson@loongson-pc:~$ gfortran getKind.f90 
loongson@loongson-pc:~$ ./a.out 
 selected_real_kind (p = 20, r = 0):          16
loongson@loongson-pc:~$ vim getKind.f90 
loongson@loongson-pc:~$ gfortran getKind.f90                                                             
loongson@loongson-pc:~$ ./a.out                                                                          
 selected_real_kind (p = 10, r = 0):           8
loongson@loongson-pc:~$ vim getKind.f90                                                                  
loongson@loongson-pc:~$ gfortran getKind.f90 
loongson@loongson-pc:~$ ./a.out 
 selected_real_kind (p = 17, r = 0):          16
```
